### PR TITLE
adding a basic CI building the project, the ISO and then running it in a nographic Qemu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: "Raccon-exok"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  TIMEOUT: 10s
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        apt install -yq nasm xorriso qemu-system-x86
+
+    - name: Make
+      shell: bash
+      run: make
+
+    - name: Make iso
+      shell: bash
+      run: |
+        sed -i 's/GRAPHICS=yes/GRAPHICS=no/' iso_root/limine.cfg
+        make iso
+
+    - name: Tests
+      shell: bash
+      run: |
+        timeout $TIMEOUT make test-nographics
+        [ $? -ne 124 ] && exit 1 || exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,7 @@ jobs:
     - name: Tests
       shell: bash
       run: |
-        timeout $TIMEOUT make test-nographics
-        [ $? -ne 124 ] && exit 1 || exit 0
+        for i in $(seq 1 4); do
+          timeout $TIMEOUT make CORE_NUM=$i test-nographics
+          [ $? -ne 124 ] && exit 1 || exit 0
+        done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,46 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    name: Build
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.name }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: ubuntu-latest, name: "Ubuntu GCC 11", cc: "gcc-11", cxx: "g++-11" }
+          - { os: ubuntu-latest, name: "Ubuntu GCC 10", cc: "gcc-10", cxx: "g++-10" }
+          - { os: ubuntu-latest, name: "Ubuntu GCC 9", cc: "gcc-9", cxx: "g++-9" }
+          - { os: ubuntu-latest, name: "Ubuntu GCC 8", cc: "gcc-8", cxx: "g++-8" }
+          - { os: ubuntu-latest, name: "Ubuntu Clang 11", cc: "clang-11", cxx: "clang++-11" }
+          - { os: ubuntu-latest, name: "Ubuntu Clang 10", cc: "clang-10", cxx: "clang++-10" }
+          - { os: ubuntu-latest, name: "Ubuntu Clang 9", cc: "clang-9", cxx: "clang++-9" }
 
     steps:
     - uses: actions/checkout@v2
 
+    - name: Update GNU compilers
+      if: startsWith(matrix.config.cc, 'gcc')
+      shell: bash
+      run: |
+        sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get -yq install ${{ matrix.config.cc }} ${{ matrix.config.cxx }}
+
+    - name: Update LLVM compilers
+      if: startsWith(matrix.config.cc, 'clang')
+      shell: bash
+      run: |
+        version=`echo ${{ matrix.config.cc }} | cut -c 7-`
+        sudo apt-get install -y clang-${version} lld-${version} libc++-${version}-dev libc++abi-${version}-dev clang-tools-${version}
+
     - name: Install dependencies
       shell: bash
       run: |
-        apt install -yq nasm xorriso qemu-system-x86
+        sudo apt install -yq nasm xorriso qemu-system-x86
 
     - name: Make
       shell: bash
-      run: make
+      run: make CC=${{ matrix.config.cc }}
 
     - name: Make iso
       shell: bash
@@ -35,7 +61,5 @@ jobs:
     - name: Tests
       shell: bash
       run: |
-        for i in $(seq 1 4); do
-          timeout $TIMEOUT make CORE_NUM=$i test-nographics
-          [ $? -ne 124 ] && exit 1 || exit 0
-        done
+        timeout $TIMEOUT make test-nographics
+        [ $? -ne 124 ] && exit 1 || exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 iso_root/
+src/limine/
 log.txt
 *.iso 
 *.elf

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ KERNEL=Raccoon-exokernel
 
 QEMU = qemu-system-x86_64
 CORE_NUM = 4
-QEMU_PARAMS_NODEBUG = -no-reboot -vga std -D ./log.txt -d int,guest_errors,in_asm -m 512M -boot d -M q35  -serial mon:stdio -m 1G -smp $(CORE_NUM) -cdrom
+QEMU_BASE_PARAMS_NODEBUG = -no-reboot -D ./log.txt -d int,guest_errors,in_asm -m 512M -boot d -M q35  -serial mon:stdio -m 1G -smp $(CORE_NUM) -cdrom
+QEMU_PARAMS_NOGRAPHICS = -nographic $(QEMU_BASE_PARAMS_NODEBUG)
+QEMU_PARAMS_GRAPHICS = -vga std $(QEMU_BASE_PARAMS_NODEBUG)
 
 all:
 	@$(MAKE) $(TARGET) -C src -s
@@ -17,7 +19,10 @@ iso:
 		-no-emul-boot iso_root -o $(KERNEL).iso
 
 test:
-	@$(QEMU) $(QEMU_PARAMS_NODEBUG) $(KERNEL).iso
+	@$(QEMU) $(QEMU_PARAMS_GRAPHICS) $(KERNEL).iso
+
+test-nographics:
+	@$(QEMU) $(QEMU_PARAMS_NOGRAPHICS) $(KERNEL).iso
 
 clean:
 	@$(MAKE) clean -C src -s


### PR DESCRIPTION
I had to modify the Makefile to change the Qemu options, so that we can launch the tests without graphics (the GitHub actions are headless runners, thus using `-vga std` wouldn't work).

I also updated the .gitignore to hide `src/limine/` as it was automatically added when running `make`.