### PR TITLE
ci: do not exit on the first non-null exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,6 @@ jobs:
     - name: Tests
       shell: bash
       run: |
+        set +e
         timeout $TIMEOUT make test-nographics
         [ $? -ne 124 ] && exit 1 || exit 0


### PR DESCRIPTION
Adding a `set +e` to disable the default behavior of quitting on the first failing command (see [this](https://github.community/t/github-action-terminates-on-first-non-zero-exit-code/240701)).
